### PR TITLE
Update custom_attributes.cpp

### DIFF
--- a/src/mod/attr/custom_attributes.cpp
+++ b/src/mod/attr/custom_attributes.cpp
@@ -1816,7 +1816,7 @@ namespace Mod::Attr::Custom_Attributes
 				float dmg_mult = 1.0f;
 				CALL_ATTRIB_HOOK_FLOAT_ON_OTHER(info.GetWeapon(), dmg_mult, mult_dmg_friendly_fire);
 				dmg *= dmg_mult;
-				if (dmg < 0.0f) {
+				if (dmg < 0.0f && pVictim->IsPlayer()) {
 					HealPlayer(ToTFPlayer(pVictim), ToTFPlayer(info.GetAttacker()), rtti_cast<CEconEntity *>(info.GetWeapon()), -dmg, true, DMG_GENERIC);
 					return 0;
 				}


### PR DESCRIPTION
This is to fix a crash that can occur when a robot shoots a friendly tank with something dealing negative damage. As far as I can tell, I only got this to crash with a Righteous Bison energy ball. This crash was discovered in the Haphazard Routine mission from Operation Madness Vs. Machines, when a [Healing Ray Soldier](https://wiki.teamfortress.com/wiki/Haphazard_Routine_(mission)#Healing_Ray_Soldier)'s energy blast came in contact with a tank. [Pictured here.](https://cdn.discordapp.com/attachments/78276459206025216/1062998274165977128/image.png)

I recompiled with the added code and it seemed to fix it.