### PR TITLE
Add bot check to $ForceRespawn inputs

### DIFF
--- a/src/mod/etc/mapentity_inputs.cpp
+++ b/src/mod/etc/mapentity_inputs.cpp
@@ -996,7 +996,7 @@ namespace Mod::Etc::Mapentity_Additions
         }},
         {"ForceRespawn"sv, false, [](CBaseEntity *ent, const char *szInputName, CBaseEntity *pActivator, CBaseEntity *pCaller, variant_t &Value){
             CTFPlayer *player = ToTFPlayer(ent);
-            if (player != nullptr) {
+            if (player != nullptr && !player->IsBot()) {
                 if (player->GetTeamNumber() >= TF_TEAM_RED && player->GetPlayerClass() != nullptr && player->GetPlayerClass()->GetClassIndex() != TF_CLASS_UNDEFINED) {
                     player->ForceRespawn();
                 }
@@ -1007,7 +1007,7 @@ namespace Mod::Etc::Mapentity_Additions
         }},
         {"ForceRespawnDead"sv, false, [](CBaseEntity *ent, const char *szInputName, CBaseEntity *pActivator, CBaseEntity *pCaller, variant_t &Value){
             CTFPlayer *player = ToTFPlayer(ent);
-            if (player != nullptr && !player->IsAlive()) {
+            if (player != nullptr && !player->IsBot() && !player->IsAlive()) {
                 if (player->GetTeamNumber() >= TF_TEAM_RED && player->GetPlayerClass() != nullptr && player->GetPlayerClass()->GetClassIndex() != TF_CLASS_UNDEFINED) {
                     player->ForceRespawn();
                 }


### PR DESCRIPTION
Firing `$ForceRespawn` or `$ForceRespawnDead` on a bot will cause unexpected behaviour, with much of the information defined for them in a popfile being absent when they respawn (custom items etc.), and reportedly may cause strange behaviour with the wave progression.
